### PR TITLE
Eliminates duplicate workflow tests & adds tests for 3.14

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,8 +1,6 @@
 name: Benchmark
 
 on:
-  push:
-    branches: [ main ]
   pull_request:
     branches: [ main ]
   workflow_dispatch:
@@ -12,7 +10,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python-version: ['3.9']
+        python-version: ['3.9', '3.14']
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,9 +11,10 @@ jobs:
   test:
     name: Test Python ${{ matrix.python-version }}
     runs-on: ubuntu-22.04
+    if: github.event_name != 'push'
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:
     - uses: actions/checkout@v3
@@ -201,7 +202,6 @@ jobs:
 
   package:
     runs-on: ubuntu-latest
-    needs: [test]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
 
     steps:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Add Python 3.14 to CI/benchmark matrices and adjust workflow triggers to avoid duplicate runs and decouple packaging.
> 
> - **CI (`.github/workflows/main.yml`)**
>   - Expand test matrix to include Python `3.14`.
>   - Skip test job on `push` events to avoid duplicate runs (`if: github.event_name != 'push'`).
>   - Remove `needs: [test]` from `package` job; package builds run only on pushes to `main`.
> - **Benchmarks (`.github/workflows/benchmark.yml`)**
>   - Add Python `3.14` to benchmark matrix.
>   - Limit triggers to `pull_request` and manual dispatch (drop `push`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9f8870ae51ee1a01245e5d7796e9a5d28e32f2ed. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->